### PR TITLE
[🐸 Frogbot] Update version of org.springframework:spring-web to 6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1252,7 +1252,7 @@
         <version.spotbugs.maven>4.9.3.0</version.spotbugs.maven>
         <version.spotbugs>4.9.3</version.spotbugs>
         <!-- Spring 6.x requires Java 17 -->
-        <version.springframework>5.3.39</version.springframework>
+        <version.springframework>6.0.0</version.springframework>
         <!-- Tomcat 10 moves from Java EE to Jakarta EE, moving packages javax.* to jakarta.* - code changes likely required to address this change. -->
         <tomcat.major.version>9</tomcat.major.version>
         <version.tomcat>9.0.97</version.tomcat>


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>



### 📦 Vulnerable Dependencies

<div align='center'>

| Severity                | ID                  | Contextual Analysis                  | Direct Dependencies                  | Impacted Dependency                  | Fixed Versions                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![critical (not applicable)](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/notApplicableCritical.png)<br>Critical | CVE-2016-1000027 | Not Applicable | org.springframework:spring-web:5.3.39 | org.springframework:spring-web 5.3.39 | [6.0.0] |

</div>


### 🔖 Details



### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Policies:** | demo |
| **Watch Name:** | github_wath |
| **Jfrog Research Severity:** | <img src="https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/smallCritical.svg" alt=""/> Critical |
| **Contextual Analysis:** | Not Applicable |
| **Direct Dependencies:** | org.springframework:spring-web:5.3.39 |
| **Impacted Dependency:** | org.springframework:spring-web:5.3.39 |
| **Fixed Versions:** | [6.0.0] |
| **CVSS V3:** | 9.8 |

Unsafe deserialization in Spring RemoteInvocationSerializingExporter could lead to remote code execution.

### 🔬 JFrog Research Details

**Description:**
Spring-based applications that export service beans as endpoints using classes that extend the [RemoteInvocationSerializingExporter](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/remoting/rmi/RemoteInvocationSerializingExporter.html) class are vulnerable to Java deserialization attacks which could lead to RCE (Remote Code Execution). As of 2016, this vulnerability is still not fixed, as the Pivotal team (the maintainers of the Spring framework) disputed it as a security vulnerability in Spring itself and decided not to issue a fix. Instead, they deprecated `HttpInvokerServiceExporter` and `SimpleHttpInvokerServiceExporter`, the potentially vulnerable exporter classes that extend `RemoteInvocationSerializingExporter` and warned application developers not to use them when exposed to untrusted user input (see "WARNING" in the [documentation](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/remoting/httpinvoker/HttpInvokerServiceExporter.html)). Applications that do not use the above classes can safely ignore this vulnerability.

**Remediation:**
##### Deployment mitigations

Do not use Java serialization for external endpoints (Do not extend the `RemoteInvocationSerializingExporter` class)



---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
