### PR TITLE
[🐸 Frogbot] Update version of org.springframework:spring-context to 6.1.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1252,7 +1252,7 @@
         <version.spotbugs.maven>4.9.3.0</version.spotbugs.maven>
         <version.spotbugs>4.9.3</version.spotbugs>
         <!-- Spring 6.x requires Java 17 -->
-        <version.springframework>5.3.39</version.springframework>
+        <version.springframework>6.1.14</version.springframework>
         <!-- Tomcat 10 moves from Java EE to Jakarta EE, moving packages javax.* to jakarta.* - code changes likely required to address this change. -->
         <tomcat.major.version>9</tomcat.major.version>
         <version.tomcat>9.0.97</version.tomcat>


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>



### 📦 Vulnerable Dependencies

<div align='center'>

| Severity                | ID                  | Contextual Analysis                  | Direct Dependencies                  | Impacted Dependency                  | Fixed Versions                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![medium](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | CVE-2024-38820 | Not Covered | org.springframework:spring-context:5.3.39 | org.springframework:spring-context 5.3.39 | [6.1.14] |

</div>


### 🔖 Details



### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Policies:** | demo |
| **Watch Name:** | github_wath |
| **Contextual Analysis:** | Not Covered |
| **Direct Dependencies:** | org.springframework:spring-context:5.3.39 |
| **Impacted Dependency:** | org.springframework:spring-context:5.3.39 |
| **Fixed Versions:** | [6.1.14] |
| **CVSS V3:** | 5.3 |

The fix for CVE-2022-22968 made disallowedFields patterns in DataBinder case insensitive. However, String.toLowerCase() has some Locale dependent exceptions that could potentially result in fields not protected as expected.


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
